### PR TITLE
Add support for `ip` command

### DIFF
--- a/evil_ssdp.py
+++ b/evil_ssdp.py
@@ -537,9 +537,14 @@ def get_ip(args):
     provided interface. This is used for serving the XML files and also for
     the SMB pointer, if not specified.
     """
-    ip_regex = r'inet (?:addr:)?(.*?) '
-    sys_ifconfig = os.popen('ifconfig ' + args.interface).read()
-    local_ip = re.findall(ip_regex, sys_ifconfig)
+    if (os.popen('which ifconfig')):
+        ip_regex = r'inet (?:addr:)?(.*?) '
+        sys_ifconfig = os.popen('ifconfig ' + args.interface).read()
+        local_ip = re.findall(ip_regex, sys_ifconfig)
+    else:
+        ip_regex = r'inet (.*?)\/'
+        sys_ifconfig = os.popen('ip address show dev ' + args.interface).read()
+        local_ip = re.findall(ip_regex, sys_ifconfig)
     try:
         return local_ip[0]
     except IndexError:


### PR DESCRIPTION
Since many new Ubuntu distros no longer came with `net-tools` installed (and therefore the `ifconfig` command), I added the support for `ip`.