### PR TITLE
Implement pure python get_ip

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+netifaces


### PR DESCRIPTION
This implements get_ip() in pure python, as opposed to shelling out to commands.